### PR TITLE
Fix lint

### DIFF
--- a/draft-darling-key-directory-over-http.md
+++ b/draft-darling-key-directory-over-http.md
@@ -333,14 +333,14 @@ Last-Modified: <datestamp>
 ~~~
 
 HEAD requests can be used by clients to cheaply determine if the directory has
-changed. The Origin server SHOULD issue a Last-Modified header with the date 
-stamp of when the key directory resource was last modified. 
+changed. The Origin server SHOULD issue a Last-Modified header with the date
+stamp of when the key directory resource was last modified.
 
-If issuing a Last-Modified header, the Origin server SHOULD support the correct 
-response to a 'If-Modified-Since' HTTP GET or HEAD request, returning the 
+If issuing a Last-Modified header, the Origin server SHOULD support the correct
+response to a 'If-Modified-Since' HTTP GET or HEAD request, returning the
 appropriate HTTP status codes {{!HTTP-CACHE=RFC9111}}
 
-It is RECOMMENDED that Mirrors support Last-Modified and 'If-Modified-Since' 
+It is RECOMMENDED that Mirrors support Last-Modified and 'If-Modified-Since'
 {{!HTTP-CACHE=RFC9111}}
 
 ## Future considerations


### PR DESCRIPTION
Run `make fix-lint` locally. This is to make CI pass again on thibmeu/draft-darling-key-directory-over-http/pull/4